### PR TITLE
Improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ user       = ftpUser
 password   = ftpPassword
 localdir   = /path/to/tmp/output/directory
 fetchdir   = (leave blank if files are in home dir)
+processdir = /path/to/dir/on/ftp/server/for/successful/ingests
+faildir    = /path/to/dir/on/ftp/server/for/failed/ingests
 [xslt]
 xslt       = /path/to/proquest/crosswalk/Proquest_MODS.xsl
 label      = xsl/getLabel.xsl

--- a/index.php
+++ b/index.php
@@ -25,7 +25,7 @@ $process->initFTP();
 // Get zip files, unzip and store locally
 $process->getFiles();
 
-//
+// Connect to Fedora API
 $process->initFedoraConnection();
 
 // Process each  

--- a/processProquest.php
+++ b/processProquest.php
@@ -52,7 +52,7 @@ class processProquest {
 
         $this->ftp = new proquestFTP($urlFTP);
         //set session time out default is 90
-        $this->ftp->ftp_set_option(FTP_TIMEOUT_SEC, 30);
+        $this->ftp->ftp_set_option(FTP_TIMEOUT_SEC, 150);
 
         $this->ftp->ftp_login($userFTP, $passwordFTP);
 
@@ -550,6 +550,12 @@ class processProquest {
                     $success_message .= "NO EMBARGO" . "\t";
                 }
                 $success_message .= $submission['LABEL'] . "\n";
+
+                $processdirFTP = $this->settings['ftp']['processdir'];
+                $directoryArray = explode('/', $directory);
+                $fnameFTP = array_values(array_slice($directoryArray, -1))[0] . '.zip';
+
+                $this->ftp->ftp_rename($fnameFTP, './processed/' . $fnameFTP);
             } else {
                 echo "Object failed to ingest\n";
 

--- a/processProquest.php
+++ b/processProquest.php
@@ -552,8 +552,14 @@ class processProquest {
                 echo "Object failed to ingest\n";
 
                 $pidcount++;
-                $failure_message .= "Failed to ingest: \t";
                 $failure_message .= $submission['PID'] . "\t";
+
+                if (isset($submission['EMBARGO'])) {
+                    $failure_message .= "EMBARGO UNTIL: " . $submission['EMBARGO'] . "\t";
+                } else {
+                    $failure_message .= "NO EMBARGO" . "\t";
+                }
+                $failure_message .= $submission['LABEL'] . "\n";
             }
 
             // JJM

--- a/processProquest.php
+++ b/processProquest.php
@@ -542,6 +542,12 @@ class processProquest {
                 echo "Ingested RELS-INT datastream\n";
             }
 
+            // Get the zip filename on the FTP server of the ETD being processed. 
+            // We'll use this in the conditional below to move the ETD on the 
+            // remove server accordingly.
+            $directoryArray = explode('/', $directory);
+            $fnameFTP = array_values(array_slice($directoryArray, -1))[0] . '.zip';
+
             if ($this->repository->ingestObject($object)) {
                 echo "Object ingested successfully\n";
 
@@ -556,9 +562,6 @@ class processProquest {
                 $successMessage .= $submission['LABEL'] . "\n";
 
                 $processdirFTP = $this->settings['ftp']['processdir'];
-                $directoryArray = explode('/', $directory);
-                $fnameFTP = array_values(array_slice($directoryArray, -1))[0] . '.zip';
-                
                 $this->ftp->ftp_rename($fnameFTP, $processdirFTP . '/' . $fnameFTP);
             } else {
                 echo "Object failed to ingest\n";
@@ -574,9 +577,6 @@ class processProquest {
                 $failureMessage .= $submission['LABEL'] . "\n";
 
                 $faildirFTP = $this->settings['ftp']['faildir'];
-                $directoryArray = explode('/', $directory);
-                $fnameFTP = array_values(array_slice($directoryArray, -1))[0] . '.zip';
-
                 $this->ftp->ftp_rename($fnameFTP, $faildirFTP . '/' . $fnameFTP);
             }
 

--- a/processProquest.php
+++ b/processProquest.php
@@ -265,7 +265,7 @@ class processProquest {
         foreach ($this->localFiles as $directory => $submission) {
     	   echo "Processing " . $directory . "\n";
             $processingMessage .= $directory . "\n";
-            
+
             if ($this->localFiles[$directory]['PROCESS'] === '1') {
                 // Still Load - but notify admin about supp files
                 echo "Supplementary files found\n";
@@ -578,7 +578,7 @@ class processProquest {
             echo "\n\n\n\n";
         }
 
-        mail($this->settings['notify']['email'],"Message from processProquest",$processingMessage . $successMessage . $failureMessage);
+        mail($this->settings['notify']['email'],"Message from processProquest",$successMessage . $failureMessage . $processingMessage);
 
     }
 }

--- a/processProquest.php
+++ b/processProquest.php
@@ -243,7 +243,7 @@ class processProquest {
         $this->api = new FedoraApi($this->connection);
         $this->repository = new FedoraRepository($this->api, new simpleCache());
 
-        $this->api_m = $this->repository->api->m; //  Management API.
+        $this->api_m = $this->repository->api->m; // Fedora Management API.
 
     }
 

--- a/processProquest.php
+++ b/processProquest.php
@@ -255,7 +255,9 @@ class processProquest {
 
         $pidcount = 0;
         $fop = '../../modules/boston_college/data/fop/cfg.xml';
-        $message = "The following ETDs were ingested:\n\n";
+        $success_message = "The following ETDs were ingested:\n\n";
+        $failure_message = "\n\nThe following ETDs failed to ingest:\n\n";
+
 
         foreach ($this->localFiles as $directory => $submission) {
     	        echo "Processing " . $directory. "\n";
@@ -534,29 +536,32 @@ class processProquest {
                 echo "Ingested RELS-INT datastream\n";
             }
 
-            $this->repository->ingestObject($object);
+            if ($this->repository->ingestObject($object)) {
+                echo "Object ingested successfully\n";
 
-            # TODO: was object ingested successfully?
-            echo "Object ingested successfully\n";
+                $pidcount++;
+                $success_message .= $submission['PID'] . "\t";
 
-            $pidcount++;
-            $message .= $submission['PID'] . "\t";
-
-            if (isset($submission['EMBARGO']))
-            {
-                $message .= "EMBARGO UNTIL: " . $submission['EMBARGO'] . "\t";
+                if (isset($submission['EMBARGO'])) {
+                    $success_message .= "EMBARGO UNTIL: " . $submission['EMBARGO'] . "\t";
+                } else {
+                    $success_message .= "NO EMBARGO" . "\t";
+                }
+                $success_message .= $submission['LABEL'] . "\n";
             } else {
-                $message .= "NO EMBARGO" . "\t";
+                echo "Object failed to ingest\n";
+
+                $pidcount++;
+                $failure_message .= "Failed to ingest: \t";
+                $failure_message .= $submission['PID'] . "\t";
             }
-            $message .= $submission['LABEL'] . "\n";
 
             // JJM
             sleep(2);
             echo "\n\n\n\n";
-
         }
 
-        mail($this->settings['notify']['email'],"Message from processProquest",$message);
+        mail($this->settings['notify']['email'],"Message from processProquest",$success_message . $failure_message);
 
     }
 }

--- a/processProquest.php
+++ b/processProquest.php
@@ -46,7 +46,7 @@ class processProquest {
      */
     function initFTP() {
 
-        echo "Initializing FTP connection...\n"
+        echo "Initializing FTP connection...\n";
 
         $urlFTP = $this->settings['ftp']['server'];
         $userFTP = $this->settings['ftp']['user'];
@@ -115,7 +115,7 @@ class processProquest {
                 }
             }
 
-            echo "Extracting files...\n"
+            echo "Extracting files...\n";
             $zip = new ZipArchive;
 
             $zip->open($localFile);
@@ -263,7 +263,7 @@ class processProquest {
 
 
         foreach ($this->localFiles as $directory => $submission) {
-    	   echo "Processing " . $directory . "\n";
+            echo "Processing " . $directory . "\n";
             $processingMessage .= $directory . "\n";
 
             if ($this->localFiles[$directory]['PROCESS'] === '1') {
@@ -558,7 +558,7 @@ class processProquest {
                 $directoryArray = explode('/', $directory);
                 $fnameFTP = array_values(array_slice($directoryArray, -1))[0] . '.zip';
 
-                $this->ftp->ftp_rename($fnameFTP, './processed/' . $fnameFTP);
+                $this->ftp->ftp_rename($fnameFTP, $processdirFTP . '/' . $fnameFTP);
             } else {
                 echo "Object failed to ingest\n";
 
@@ -571,6 +571,12 @@ class processProquest {
                     $failureMessage .= "NO EMBARGO" . "\t";
                 }
                 $failureMessage .= $submission['LABEL'] . "\n";
+
+                $faildirFTP = $this->settings['ftp']['faildir'];
+                $directoryArray = explode('/', $directory);
+                $fnameFTP = array_values(array_slice($directoryArray, -1))[0] . '.zip';
+
+                $this->ftp->ftp_rename($fnameFTP, $faildirFTP . '/' . $fnameFTP);
             }
 
             // JJM

--- a/processProquest.php
+++ b/processProquest.php
@@ -253,14 +253,16 @@ class processProquest {
      *
      */
     function ingest() {
+
         echo "\n\nNow ingesting files...\n\n";
 
         $pidcount = 0;
         $fop = '../../modules/boston_college/data/fop/cfg.xml';
-        $processingMessage = "The following directories were processed in {$this->settings['ftp']['localdir']}:\n\n";
-        $successMessage = "\n\nThe following ETDs were ingested successfully:\n\n";
-        $failureMessage = "\n\nThe following ETDs failed to ingest:\n\n";
 
+        // Initialize messages for notification email
+        $successMessage = "The following ETDs ingested successfully:\n\n";
+        $failureMessage = "\n\nThe following ETDs failed to ingest:\n\n";
+        $processingMessage = "\n\nThe following directories were processed in {$this->settings['ftp']['localdir']}:\n\n";
 
         foreach ($this->localFiles as $directory => $submission) {
             echo "Processing " . $directory . "\n";
@@ -382,7 +384,6 @@ class processProquest {
     		}
 
             $this->localFiles[$directory]['SPLASH'] = 'splash.pdf';
-
 
             /**
              * Load Splash to PDF if under embargo
@@ -557,7 +558,7 @@ class processProquest {
                 $processdirFTP = $this->settings['ftp']['processdir'];
                 $directoryArray = explode('/', $directory);
                 $fnameFTP = array_values(array_slice($directoryArray, -1))[0] . '.zip';
-
+                
                 $this->ftp->ftp_rename($fnameFTP, $processdirFTP . '/' . $fnameFTP);
             } else {
                 echo "Object failed to ingest\n";
@@ -584,7 +585,15 @@ class processProquest {
             echo "\n\n\n\n";
         }
 
-        mail($this->settings['notify']['email'],"Message from processProquest",$successMessage . $failureMessage . $processingMessage);
+        // Do not show failure message in notification if no ETDs failed 
+        // (same with success message, but hopefully we won't have that problem!)
+        if ($failureMessage == "\n\nThe following ETDs failed to ingest:\n\n") {
+            mail($this->settings['notify']['email'],"Message from processProquest",$successMessage . $processingMessage);
+        } elseif ($successMessage == "The following ETDs successfully ingested:\n\n") {
+            mail($this->settings['notify']['email'],"Message from processProquest",$failureMessage . $processingMessage);
+        } else {
+            mail($this->settings['notify']['email'],"Message from processProquest",$successMessage . $failureMessage . $processingMessage);
+        }
 
     }
 }

--- a/processProquest.php
+++ b/processProquest.php
@@ -255,12 +255,14 @@ class processProquest {
 
         $pidcount = 0;
         $fop = '../../modules/boston_college/data/fop/cfg.xml';
-        $success_message = "The following ETDs were ingested:\n\n";
+        $processing_message = "The following directories were processed in {$this->settings['ftp']['localdir']}:\n\n";
+        $success_message = "\n\nThe following ETDs were ingested successfully:\n\n";
         $failure_message = "\n\nThe following ETDs failed to ingest:\n\n";
 
 
         foreach ($this->localFiles as $directory => $submission) {
-    	        echo "Processing " . $directory. "\n";
+    	        echo "Processing " . $directory . "\n";
+                $processing_message .= $directory . "\n";
             if ($this->localFiles[$directory]['PROCESS'] === '1') {
                 // Still Load - but notify admin about supp files
                 echo "Supplementary files found\n";
@@ -567,7 +569,7 @@ class processProquest {
             echo "\n\n\n\n";
         }
 
-        mail($this->settings['notify']['email'],"Message from processProquest",$success_message . $failure_message);
+        mail($this->settings['notify']['email'],"Message from processProquest",$processing_message . $success_message . $failure_message);
 
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### What does this PR do?
Includes some much needed improvements on how processProquest documents and responds to errors. The notification email now says which ETDs successfully ingested and which failed to ingest, and it lists the directory names of all ETDs that it attempted to process.

Additionally, the `ingest` function now moves ETDs that were successfully and unsuccessfully ingested to corresponding directories on the FTP server. This is an improvement over the previous method, which we had since removed, that moved everything to a 'processed' directory whether it succeeded or failed.

### Motivation and context
We've been having issues with ProQuest ETD ingests recently. More verbose error will help us keep better track of which ETDs need further attention.

### How has this been tested?
Tested in our dev environment with two recent ProQuest ETDs.

### How can a reviewer see the effects of these changes?
Run it from the dev environment and confirm the changes in the notification message.

### Related tickets
https://trello.com/c/S5SFjgQ8/48-improve-processproquest-error-handling

### Screenshots
<!-- Include relevant screenshots if necessary -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have tested this code.
- [x] This PR requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have stakeholder approval to make this change.
