### PR TITLE
More bug fixes

### DIFF
--- a/index.php
+++ b/index.php
@@ -39,7 +39,7 @@ exit(1);
 
 function usage() {
     echo "Usage: php index.php processProquest.ini\n";
-    echo "(See README.md for configuration info)"
+    echo "(See README.md for configuration info)";
 }
 
 ?>

--- a/processProquest.php
+++ b/processProquest.php
@@ -88,6 +88,7 @@ class processProquest {
             mkdir($etdDir, 0755);
             $localFile = $etdDir . "/" .$filename;
             $this->ftp->ftp_get($localFile, $filename, FTP_BINARY);
+            sleep(5);
 
             // Store location
             if(isset($this->localFiles[$etdDir])){$this->localFiles[$etdDir];}
@@ -518,7 +519,7 @@ class processProquest {
              * Set Embargo is there is one
              * Permanent?
              */
-            
+
             //Initialize $relsint or the script will fail
             $relsint = '';
             if ($submission['OA'] === 0) {
@@ -542,8 +543,8 @@ class processProquest {
                 echo "Ingested RELS-INT datastream\n";
             }
 
-            // Get the zip filename on the FTP server of the ETD being processed. 
-            // We'll use this in the conditional below to move the ETD on the 
+            // Get the zip filename on the FTP server of the ETD being processed.
+            // We'll use this in the conditional below to move the ETD on the
             // remove server accordingly.
             $directoryArray = explode('/', $directory);
             $fnameFTP = array_values(array_slice($directoryArray, -1))[0] . '.zip';
@@ -585,7 +586,7 @@ class processProquest {
             echo "\n\n\n\n";
         }
 
-        // Do not show failure message in notification if no ETDs failed 
+        // Do not show failure message in notification if no ETDs failed
         // (same with success message, but hopefully we won't have that problem!)
         if ($failureMessage == "\n\nThe following ETDs failed to ingest:\n\n") {
             mail($this->settings['notify']['email'],"Message from processProquest",$successMessage . $processingMessage);

--- a/processProquest.php
+++ b/processProquest.php
@@ -87,8 +87,9 @@ class processProquest {
 
             mkdir($etdDir, 0755);
             $localFile = $etdDir . "/" .$filename;
+
+            sleep(2);
             $this->ftp->ftp_get($localFile, $filename, FTP_BINARY);
-            sleep(5);
 
             // Store location
             if(isset($this->localFiles[$etdDir])){$this->localFiles[$etdDir];}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### What does this PR do?
Adds a two-second pause before fetching each ETD and missing semicolon in usage info.

### Motivation and context
The pause is motivated by an FTP error that occasionally occurs during transfer. Initial testing indicates that adding a brief pause prior to fetch fixes this error; however, we will need to monitor this in production.

### How has this been tested?
Ran multiple times in dev successfully.

### How can a reviewer see the effects of these changes?
Move some ETDs to the appropriate directory on the FTP server and run the script manually.

### Related tickets
#2 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have tested this code.
- [ ] This PR requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have stakeholder approval to make this change.
